### PR TITLE
Fix typo in spec-1_0.md

### DIFF
--- a/spec-1_0.md
+++ b/spec-1_0.md
@@ -188,7 +188,7 @@ size (in 8-bit bytes) of each part.
 
   Second bundle element's contents   As many bytes as given by "size of second bundle element"    Second bundle element
 
-  etc.                                                                                            Addtional bundle elements
+  etc.                                                                                            Additional bundle elements
 
   ---------------------------------- ------------------------------------------------------------ --------------------------------------
 


### PR DESCRIPTION
On the last line of the table of parts of a two-or-more element OSC bundle, corrected "Addtional" to "Additional"